### PR TITLE
Tradução data

### DIFF
--- a/_includes/date.html
+++ b/_includes/date.html
@@ -1,0 +1,17 @@
+{% assign m = page.date | date: "%-m" %}
+{{ page.date | date: "%-d"}} de 
+{% case m %}
+  {% when '1' %}Janeiro
+  {% when '2' %}Fevereiro
+  {% when '3' %}Março
+  {% when '4' %}Abril
+  {% when '5' %}Maio
+  {% when '6' %}Junho
+  {% when '7' %}Julho
+  {% when '8' %}Agosto
+  {% when '9' %}Setembro
+  {% when '10' %}Outubro
+  {% when '11' %}Novembro
+  {% when '12' %}Dezembro
+{% endcase %} de
+{{ page.date | date: "%Y" }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,24 +45,7 @@ layout: default
 
 <section class="post-meta">
   <div class="post-date">
-    <!-- Whitespace added for readability -->
-    {% assign m = post.date | date: "%-m" %}
-    {{ post.date | date: "%-d" }} de
-    {% case m %}
-      {% when '1' %}Janeiro
-      {% when '2' %}Fevereiro
-      {% when '3' %}Mar&ccedil;o
-      {% when '4' %}Abril
-      {% when '5' %}Maio
-      {% when '6' %}Junho
-      {% when '7' %}Julho
-      {% when '8' %}Agosto
-      {% when '9' %}Setembro
-      {% when '10' %}Outubro
-      {% when '11' %}Novembro
-      {% when '12' %}Dezembro
-    {% endcase %} de
-    {{ post.date | date: "%Y" }}
+		{% include date.html %}
   </div>
   <div class="post-categories">
   {% if page.categories.size > 0 %}em {% for cat in page.categories %}

--- a/index.html
+++ b/index.html
@@ -14,37 +14,20 @@ layout: default
 
 <div class="wrapper">
 <ul class="post-list">
-  {% for post in paginator.posts %}
+  {% for page in paginator.posts %}
   <li>
     <h2>
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      <a class="post-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
     </h2>
     <section class="post-excerpt" itemprop="description">
-      <p>{{ post.content | strip_html | truncatewords: 50 }}</p>
+      <p>{{ page.content | strip_html | truncatewords: 50 }}</p>
     </section>
     <section class="post-meta">
       <div class="post-date">
-        <!-- Whitespace added for readability -->
-        {% assign m = post.date | date: "%-m" %}
-        {{ post.date | date: "%-d" }} de
-        {% case m %}
-          {% when '1' %}Janeiro
-          {% when '2' %}Fevereiro
-          {% when '3' %}Mar&ccedil;o
-          {% when '4' %}Abril
-          {% when '5' %}Maio
-          {% when '6' %}Junho
-          {% when '7' %}Julho
-          {% when '8' %}Agosto
-          {% when '9' %}Setembro
-          {% when '10' %}Outubro
-          {% when '11' %}Novembro
-          {% when '12' %}Dezembro
-        {% endcase %} de
-        {{ post.date | date: "%Y" }}
+				{% include date.html %}
       </div>
       <div class="post-categories">
-      {% if post.categories.size > 0 %}em {% for cat in post.categories %}
+      {% if page.categories.size > 0 %}em {% for cat in page.categories %}
         {% if site.jekyll-archives %}
         <a href="{{ site.baseurl }}/category/{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
         {% else %}


### PR DESCRIPTION
Resolvido problema de tradução da data, discutido aqui #9 , aqui #11 e também aqui #16 .

Criei um layout para ser incluso nas páginas, pois assim podemos reutilizar sem dificuldades em outras páginas que quisermos, apenas adotando `page` como marcador para chegar à data.
