### PR TITLE
Docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-gem 'github-pages'
-gem 'sequel'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ $ gem install jekyll-paginate
 $ gem install jekyll-sitemap
 ~~~
 
+## Docker
+
+Em alternativa a ter de sujar sua máquina com instalações assim para cada projeto pode-se utilizar Docker!
+
+Veja a documentação do [Docker] para instalar em sua máquina. Rodamos testes com [essa imagem][docker-githubpages] configurada para aplicações que vão rodar no Github Pages e funcionou bem.
+
+Para rodar, você executa o seguinte comando:
+
+~~~
+$ docker run -d --name phpba -v "$(pwd):/usr/src/app" -p 4000:4000 starefossen/github-pages
+~~~
+
+E então já poderá acessar [http://localhost:4000](http://localhost:4000) para ver o blog.
+
+Caso tenha feito alterações e por algum motivo não foram atualizadas, reinicia o container da seguinte maneira:
+
+~~~
+$ docker restart phpba
+~~~
+
 ## Uso
 
 Poderá fazer as modificações e já ir vendo o resultado. Para tal:
@@ -84,3 +104,5 @@ Na documentação do [Jekyll](http://jekyllrb.com/docs/posts/) tem outras inform
 [contribuidores]: https://github.com/phpba/phpba.github.io/graphs/contributors
 [author]: https://github.com/bencentra/
 [theme]: https://github.com/bencentra/centrarium
+[docker]: https://docs.docker.com/engine/installation/linux/
+[docker-githubpages]: https://hub.docker.com/r/starefossen/github-pages/


### PR DESCRIPTION
Seguindo a sugestão de @vinaocruz, coloquei informações no `README.md` para como usar com Docker.

Testei essa imagem e funcionou tranquilo. Preferí essa em alternativa à indicada por @paulodealmeida pois essa já tem as coisas que o Github roda no Pages.

Adiciona info para rodar blog em container Docker
closes #81
